### PR TITLE
Added RailsSortable::Model#sortable_id

### DIFF
--- a/app/models/rails_sortable/model.rb
+++ b/app/models/rails_sortable/model.rb
@@ -29,6 +29,10 @@ module RailsSortable
       end
     end
 
+    def sortable_id
+      "#{self.class}_#{self.id}"
+    end
+
   protected
 
     def maximize_sort

--- a/spec/models/rails_sortable/model_spec.rb
+++ b/spec/models/rails_sortable/model_spec.rb
@@ -53,6 +53,13 @@ describe RailsSortable::Model, type: :model do
     end
   end
 
+  describe "sortable_id" do
+    it "should return a correct sortable_id" do
+      item = Item.create!
+      expect(item.sortable_id).to eq("Item_#{item.id}") 
+    end
+  end
+
   describe "each_with_sortable_id" do
     it "should make models iterable with sortable ids" do
       items = 2.times.map { |i| Item.create! sort: i }


### PR DESCRIPTION
A simple sortable_id method on for classes which include RailsSortable::Model. Returns the same sortable_id as Enumerable#each_with_sortable_id but is useful in cases where that enumeration method is inconvenient.