### PR TITLE
Allow to use ID of any type, not only integer

### DIFF
--- a/app/controllers/sortable_controller.rb
+++ b/app/controllers/sortable_controller.rb
@@ -25,6 +25,6 @@ private
 
   def find_model(token)
     klass, id = VERIFIER.verify(token).match(/class=(.+),id=(.+)/)[1..2]
-    klass.constantize.find(id.to_i)
+    klass.constantize.find(id)
   end
 end


### PR DESCRIPTION
Type coercion already works fine if the id is an integer, string, or uuid