### PR TITLE
Add without_validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ and `Item` model as
 class Item < ApplicationRecord
   include RailsSortable::Model
   set_sortable :sort  # Indicate a sort column
-  # If you do NOT want timestamps to be updated on sorting, use the following option.
-  # set_sortable :sort, without_updating_timestamps: true
+  # set_sortable :sort,
+  #  without_updating_timestamps: true, # If you do NOT want timestamps to be updated on sorting
+  #  without_validations: true # # If you do NOT want validations to be run on sorting
+
 end
 ```
 and `ItemsController` as

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class Item < ApplicationRecord
   set_sortable :sort  # Indicate a sort column
   # set_sortable :sort,
   #  without_updating_timestamps: true, # If you do NOT want timestamps to be updated on sorting
-  #  without_validations: true # # If you do NOT want validations to be run on sorting
+  #  without_validations: true # If you do NOT want validations to be run on sorting
 
 end
 ```

--- a/app/models/rails_sortable/model.rb
+++ b/app/models/rails_sortable/model.rb
@@ -19,13 +19,15 @@ module RailsSortable
 
     def update_sort!(new_value)
       write_attribute sort_attribute, new_value
+      without_validations = self.class.sortable_options[:without_validations]
+
       if self.class.sortable_options[:silence_recording_timestamps]
         warn "[DEPRECATION] `silence_recording_timestamps` is deprecated. Please use `without_updating_timestamps` instead."
-        without_updating_timestamps { save! }
+        without_updating_timestamps { save_as_desired(without_validations) }
       elsif self.class.sortable_options[:without_updating_timestamps]
-        without_updating_timestamps { save! }
+        without_updating_timestamps { save_as_desired(without_validations) }
       else
-        save!
+        save_as_desired(without_validations)
       end
     end
 
@@ -52,6 +54,10 @@ module RailsSortable
       (self.class.maximum(sort_attribute) || 0) + 1
     end
 
+    def save_as_desired(without_validations)
+      without_validations ? save(validate: false) : save!
+    end
+
     def sort_attribute
       self.class.sort_attribute
     end
@@ -61,6 +67,8 @@ module RailsSortable
       # allowed options
       # - without_updating_timestamps
       #     When it is true, timestamp(updated_at) will be NOT touched on reordering.
+      # - without_validations
+      #     When it is true, validations will be skipped
       #
       def set_sortable(attribute, options = {})
         self.define_singleton_method(:sort_attribute) { attribute }

--- a/lib/rails_sortable/version.rb
+++ b/lib/rails_sortable/version.rb
@@ -1,3 +1,3 @@
 module RailsSortable
-  VERSION = '1.4.1'
+  VERSION = '1.5.0'
 end

--- a/spec/dummy/app/models/validated_item.rb
+++ b/spec/dummy/app/models/validated_item.rb
@@ -1,0 +1,4 @@
+class ValidatedItem < Item
+  self.table_name = "items"
+  validates_presence_of :title
+end

--- a/spec/models/rails_sortable/model_spec.rb
+++ b/spec/models/rails_sortable/model_spec.rb
@@ -73,7 +73,6 @@ describe RailsSortable::Model, type: :model do
           end
         end
 
-        # defaults falsey
         it "will require validations" do
           item = ValidatedItem.create!(title: "Title")
           item.update_attribute(:title, nil)

--- a/spec/models/rails_sortable/model_spec.rb
+++ b/spec/models/rails_sortable/model_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe RailsSortable::Model, type: :model do
-
   describe "before_create" do
     context "when sort is nil" do
       it "should be automatically set maximum sort value" do
@@ -48,6 +47,39 @@ describe RailsSortable::Model, type: :model do
         it "should modify timestamps" do
           item = Item.create!
           expect { item.update_sort!(1000) }.to change(item, :updated_at)
+        end
+      end
+    end
+
+    describe "without_validations" do
+      context "when optional value is true" do
+        before do
+          ValidatedItem.class_eval do
+            set_sortable :sort, without_validations: true
+          end
+        end
+
+        it "will skip validations" do
+          item = ValidatedItem.create!(title: "Title")
+          item.update_attribute(:title, nil)
+          expect { item.update_sort!(1000) }.not_to raise_error
+        end
+      end
+
+      context "when optional value is false" do
+        before do
+          ValidatedItem.class_eval do
+            set_sortable :sort, without_validations: false
+          end
+        end
+
+        # defaults falsey
+        it "will require validations" do
+          item = ValidatedItem.create!(title: "Title")
+          item.update_attribute(:title, nil)
+          expect do
+            item.update_sort!(1000)
+          end.to raise_error(ActiveRecord::RecordInvalid, /Title can't be blank/)
         end
       end
     end


### PR DESCRIPTION
Looking to allow the ability to skip validations when we are dragging and dropping to sort

Use case: old crusty data that is being sorted but since created new validations have been added.